### PR TITLE
Support padding along the top that is not viewable

### DIFF
--- a/jquery.visible.js
+++ b/jquery.visible.js
@@ -15,8 +15,8 @@
 	    var $t				= $(this).eq(0),
 	    	t				= $t.get(0),
 	    	$w				= $(window),
-	    	topPadding		= viewPortPadding ? viewPortPadding.top ? viewPortPadding.top : 0 : 0;
-	    	bottomPadding		= viewPortPadding ? viewPortPadding.bottom ? viewPortPadding.bottom : 0 : 0;
+	    	topPadding		= viewPortPadding ? viewPortPadding.top ? viewPortPadding.top : 0 : 0,
+	    	bottomPadding		= viewPortPadding ? viewPortPadding.bottom ? viewPortPadding.bottom : 0 : 0,
 	    	viewTop			= $w.scrollTop() + topPadding,
 	    	viewBottom		= viewTop + $w.height() - topPadding - bottomPadding,
 	    	_top			= $t.offset().top,


### PR DESCRIPTION
My site has a fixed menu header and footer that obscures content. If the element in question is hidden by the header or footer then it should not be considered visible. 

var topPadding = $("body header").height();
var isVisible = jqElem.visible(true, false, {top: topPadding});
