### PR TITLE
Update jquery.visible.js - dealing with elements larger than window height

### DIFF
--- a/jquery.visible.js
+++ b/jquery.visible.js
@@ -29,10 +29,12 @@
             var rec = t.getBoundingClientRect(),
                 tViz = rec.top    >= 0 && rec.top    <  vpHeight,
                 bViz = rec.bottom >  0 && rec.bottom <= vpHeight,
+                mVis = rec.top    <  0 && rec.bottom >  vpHeight,   
                 lViz = rec.left   >= 0 && rec.left   <  vpWidth,
                 rViz = rec.right  >  0 && rec.right  <= vpWidth,
-                vVisible   = partial ? tViz || bViz : tViz && bViz,
-                hVisible   = partial ? lViz || lViz : lViz && rViz;
+                hmVis= rec.left   <  0 && rec.right  >  vpWidth,
+                vVisible   = partial ? tViz || bViz || mVis : tViz && bViz,
+                hVisible   = partial ? lViz || lViz ||hmVis : lViz && rViz;
 
             if(direction === 'both')
                 return clientSize && vVisible && hVisible;
@@ -57,11 +59,11 @@
                 compareRight    = partial === true ? _left : _right;
 
             if(direction === 'both')
-                return !!clientSize && ((compareBottom <= viewBottom) && (compareTop >= viewTop)) && ((compareRight <= viewRight) && (compareLeft >= viewLeft));
+                return !!clientSize && (((compareBottom <= viewBottom) && (compareTop >= viewTop)) || (partial === true && compareTop > ViewBottom && CompareBottom < viewTop)) && (((compareRight <= viewRight) && (compareLeft >= viewLeft)) || (partial === true && compareLeft > ViewRight && CompareRight < viewLeft));
             else if(direction === 'vertical')
-                return !!clientSize && ((compareBottom <= viewBottom) && (compareTop >= viewTop));
+                return !!clientSize && (((compareBottom <= viewBottom) && (compareTop >= viewTop)) || (partial === true && compareTop > ViewBottom && CompareBottom < viewTop));
             else if(direction === 'horizontal')
-                return !!clientSize && ((compareRight <= viewRight) && (compareLeft >= viewLeft));
+                return !!clientSize && (((compareRight <= viewRight) && (compareLeft >= viewLeft)) || (partial === true && compareLeft > ViewRight && CompareRight < viewLeft));
         }
     };
 


### PR DESCRIPTION
If the element is larger than the window it will register as not visible when edges are off screen. To fix this I added checks if element top is above screen top && element bottom is below screen bottom.

The non-native method is rather ugly
